### PR TITLE
AsyncClient interface

### DIFF
--- a/asynchclient.go
+++ b/asynchclient.go
@@ -877,13 +877,13 @@ func (c *asyncClient) Hset(arg0 string, arg1 string, arg2 []byte) (stat FutureBo
 }
 
 // Redis HGETALL command.
-func (c *asyncClient) Hgetall(arg0 string) (result FutureBytes, err Error) {
+func (c *asyncClient) Hgetall(arg0 string) (result FutureBytesArray, err Error) {
 	arg0bytes := []byte(arg0)
 
 	var resp *PendingResponse
 	resp, err = c.conn.QueueRequest(&HGETALL, [][]byte{arg0bytes})
 	if err == nil {
-		result = resp.future.(FutureBytes)
+		result = resp.future.(FutureBytesArray)
 	}
 	return result, err
 

--- a/redis.go
+++ b/redis.go
@@ -516,7 +516,7 @@ type AsyncClient interface {
 	Hset(key string, hashkey string, arg1 []byte) (stat FutureBool, err Error)
 
 	// Redis HGETALL command.
-	Hgetall(key string) (result FutureBytes, err Error)
+	Hgetall(key string) (result FutureBytesArray, err Error)
 
 	// Redis FLUSHDB command.
 	Flushdb() (status FutureBool, err Error)

--- a/redis.go
+++ b/redis.go
@@ -509,6 +509,15 @@ type AsyncClient interface {
 	// Redis ZRANGEBYSCORE command.
 	Zrangebyscore(key string, arg1 float64, arg2 float64) (result FutureBytesArray, err Error)
 
+	// Redis HGET command.
+	Hget(key string, hashkey string) (result FutureBytes, err Error)
+
+	// Redis HSET command.
+	Hset(key string, hashkey string, arg1 []byte) (stat FutureBool, err Error)
+
+	// Redis HGETALL command.
+	Hgetall(key string) (result FutureBytes, err Error)
+
 	// Redis FLUSHDB command.
 	Flushdb() (status FutureBool, err Error)
 

--- a/synchclient.go
+++ b/synchclient.go
@@ -51,11 +51,10 @@ func NewSynchClient() (c Client, err Error) {
 //
 func NewSynchClientWithSpec(spec *ConnectionSpec) (c Client, err Error) {
 	_c := new(syncClient)
-	_c.conn, err = NewSyncConnection(spec)
+    _c.conn, err = NewSyncConnection(spec)
 	if err != nil {
-		return nil, withError (err)
-	}
-//	_c.conn = conn
+	   return nil, withError (err)
+    }
 	return _c, nil
 }
 


### PR DESCRIPTION
Addresses incorrect return type for Hgetall in rday's Async HGET, HGETALL, and HSET fix for issue #18
