### PR TITLE
Leave flag.Parse() to the main().

### DIFF
--- a/bench/synchclient.go
+++ b/bench/synchclient.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"redis"
@@ -30,6 +31,7 @@ func failedTest(msg string) error {
 	return nil
 }
 func main() {
+	flag.Parse()
 	cnt := 20000
 
 	doOne(cnt)

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -39,6 +40,8 @@ const (
 // a list of canonical Redis methods obtained from a
 // spec file and reports the missing methods
 func main() {
+	flag.Parse()
+
 	specfname, e := getSpecFileName("compliance.prop")
 	if e != nil {
 		log.Println("error -", e)

--- a/examples/ciao.go
+++ b/examples/ciao.go
@@ -15,10 +15,11 @@
 package main 
 
 import (
-	"os";
 	"bufio";
 	"log";
+	"flag"
 	"fmt";
+	"os";
 	"redis";
 )
 
@@ -27,6 +28,9 @@ import (
 */
 
 func main () {
+
+	// Parse command-line flags; needed to let flags used by Go-Redis be parsed.
+	flag.Parse()
 
 	// create the client.  Here we are using a synchronous client.
 	// Using the default ConnectionSpec, we are specifying the client to connect

--- a/redis.go
+++ b/redis.go
@@ -94,7 +94,6 @@ package redis
 
 import (
 	"flag"
-	"runtime";
 )
 
 // Common interface supported by all clients
@@ -535,10 +534,11 @@ type AsyncClient interface {
 // go-redis will make use of command line flags where available.  flag names
 // for this package are all prefixed by "redis:" to prevent possible name collisions.
 //
-func init() {
-		runtime.GOMAXPROCS(2);
-		flag.Parse();
-}
+// Note that because flag.Parse() can only be called once, add all flags must have
+// been defined by the time it is called, we CAN NOT call flag.Parse() in our init()
+// function, as that will prevent any invokers from defining their own flags.
+//
+// It is your responsibility to call flag.Parse() at the start of your main().
 
 // redis:d
 //


### PR DESCRIPTION
Calling flag.Parse() in our init() inhibits others from using the flag module.

All flag definitions must happen before flag.Parse() is called, and flag.Parse() can only effectively be called once.  So a client pulling in Go-Redis also using the flag module would get an error of the form:
 flag provided but not defined: -the-client-app-flag

We can't effectively coerce that flag.Parse() must happen, unless we use sync.Once to call it in our own API guarded by a call to flag.Parsed().
