### PR TITLE
Simple change to the benchmark import description.

### DIFF
--- a/bench/asyncbench.go
+++ b/bench/asyncbench.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"redis"
+	redis "github.com/alphazero/Go-redis"
 	"time"
 )
 

--- a/bench/gosynchclient.go
+++ b/bench/gosynchclient.go
@@ -19,7 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"redis"
+	redis "github.com/alphazero/Go-redis"
 	"time"
 )
 

--- a/bench/synchclient.go
+++ b/bench/synchclient.go
@@ -18,7 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"redis"
+	redis "github.com/alphazero/Go-redis"
 	"time"
 )
 


### PR DESCRIPTION
Quick change that allows the benchmark files to be run without modifying GOPATH. With this change it should be possible to run the following series of commands 

go get github.com/alphazero/Go-redis
echo "requirepass go-redis" | redis-server - &
for i in src/github.com/alphazero/Go-redis/bench/*.go ; do
        go run $i
done
kill %1

The idea is to make it super simple to run.

Tested using the above commands.
