### PR TITLE
Implemented the SETEX command. Also added a setex.go example that shows ...

### DIFF
--- a/asynchclient.go
+++ b/asynchclient.go
@@ -203,6 +203,20 @@ func (c *asyncClient) Setnx(arg0 string, arg1 []byte) (result FutureBool, err Er
 
 }
 
+// Redis SETEX command.
+func (c *asyncClient) Setex(arg0 string, arg1 int64, arg2 []byte) (stat FutureBool, err Error) {
+	arg0bytes := []byte(arg0)
+	arg1bytes := []byte(fmt.Sprintf("%d", arg1))
+	arg2bytes := arg2
+
+	resp, err := c.conn.QueueRequest(&SETEX, [][]byte{arg0bytes, arg1bytes, arg2bytes})
+	if err == nil {
+		stat = resp.future.(FutureBool)
+	}
+
+	return
+}
+
 // Redis GETSET command.
 func (c *asyncClient) Getset(arg0 string, arg1 []byte) (result FutureBytes, err Error) {
 	arg0bytes := []byte(arg0)

--- a/examples/setex.go
+++ b/examples/setex.go
@@ -1,0 +1,59 @@
+//   Copyright 2009 Joubin Houshyar
+// 
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//    
+//   http://www.apache.org/licenses/LICENSE-2.0
+//    
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"redis"
+)
+
+// Test Setex command
+func main() {
+
+	// Parse command-line flags; needed to let flags used by Go-Redis be parsed.
+	flag.Parse()
+
+	spec := redis.DefaultSpec().Db(13).Password("go-redis")
+	client, e := redis.NewSynchClientWithSpec(spec)
+	if e != nil {
+		log.Println("failed to create the client", e)
+		return
+	}
+
+	key := "expire:test"
+
+	if err := client.Setex(key, 120, []byte("dummy-key-value")); err != nil {
+		log.Println("error on Setex", err)
+		return
+	}
+
+	value, e := client.Get(key)
+	if e != nil {
+		log.Println("error on Get", e)
+		return
+	}
+
+	ttl, e := client.Ttl(key)
+	if e != nil {
+		log.Println("error on Ttl", e)
+		return
+	}
+
+	fmt.Printf("%s with value %s expires in %d seconds", key, value, ttl)
+
+	return
+}

--- a/redis.go
+++ b/redis.go
@@ -149,6 +149,9 @@ type Client interface {
 	// Redis SETNX command.
 	Setnx(key string, arg1 []byte) (result bool, err Error)
 
+	// Redis SETEX command.
+	Setex(key string, arg1 int64, arg2 []byte) (err Error)
+
 	// Redis GETSET command.
 	Getset(key string, arg1 []byte) (result []byte, err Error)
 
@@ -369,6 +372,9 @@ type AsyncClient interface {
 
 	// Redis SETNX command.
 	Setnx(key string, arg1 []byte) (result FutureBool, err Error)
+
+	// Redis SETEX command.
+	Setex(key string, arg1 int64, arg2 []byte) (result FutureBool, err Error)
 
 	// Redis GETSET command.
 	Getset(key string, arg1 []byte) (result FutureBytes, err Error)

--- a/specification.go
+++ b/specification.go
@@ -85,6 +85,7 @@ const (
 	KEY_NUM
 	KEY_SPEC
 	KEY_NUM_NUM
+	KEY_NUM_VALUE
 	KEY_VALUE
 	KEY_IDX_VALUE
 	KEY_KEY_VALUE
@@ -126,6 +127,7 @@ var (
 	GETSET        Command = Command{"GETSET", KEY_VALUE, BULK}
 	MGET          Command = Command{"MGET", MULTI_KEY, MULTI_BULK}
 	SETNX         Command = Command{"SETNX", KEY_VALUE, BOOLEAN}
+	SETEX         Command = Command{"SETEX", KEY_NUM_VALUE, STATUS}
 	INCR          Command = Command{"INCR", KEY, NUMBER}
 	INCRBY        Command = Command{"INCRBY", KEY_NUM, NUMBER}
 	DECR          Command = Command{"DECR", KEY, NUMBER}

--- a/synchclient.go
+++ b/synchclient.go
@@ -226,6 +226,17 @@ func (c *syncClient) Setnx(arg0 string, arg1 []byte) (result bool, err Error) {
 
 }
 
+// Redis SETEX command.
+func (c *syncClient) Setex(arg0 string, arg1 int64, arg2 []byte) (err Error) {
+	arg0bytes := []byte(arg0)
+	arg1bytes := []byte(fmt.Sprintf("%d", arg1))
+	arg2bytes := arg2
+
+	//var resp Response
+	_, err = c.conn.ServiceRequest(&SETEX, [][]byte{arg0bytes, arg1bytes, arg2bytes})
+	return
+}
+
 // Redis GETSET command.
 func (c *syncClient) Getset(arg0 string, arg1 []byte) (result []byte, err Error) {
 	arg0bytes := []byte(arg0)

--- a/synchclient_test.go
+++ b/synchclient_test.go
@@ -119,6 +119,21 @@ func TestSetnx(t *testing.T) {
 	flushAndQuitOnCompletion(t, client)
 }
 
+func TestSetex(t *testing.T) {
+	client, e := _test_getDefaultSyncClient()
+	if e != nil {
+		t.Fatalf("on getDefaultClient - %s", e)
+	}
+
+	for k, v := range testdata[_testdata_kv].(map[string][]byte) {
+		if e := client.Setex(k, 120, v); e != nil {
+			t.Errorf("on Setex(%s, 120, %s) - %s", k, v, e)
+		}
+	}
+
+	flushAndQuitOnCompletion(t, client)
+}
+
 func TestGetset(t *testing.T) {
 	client, e := _test_getDefaultSyncClient()
 	if e != nil {


### PR DESCRIPTION
...how it's used (this also doubles as a test case). Test case implemented for the synchclient to be on par with the rest of the commands.
